### PR TITLE
fix src/android/uninstall_conflict_plugin.js

### DIFF
--- a/src/android/uninstall_conflict_plugin.js
+++ b/src/android/uninstall_conflict_plugin.js
@@ -2,7 +2,7 @@ module.exports = function (ctx) {
 
   var PluginInfoProvider = ctx.requireCordovaModule('cordova-common').PluginInfoProvider;
 
-  var path = ctx.requireCordovaModule('path');
+  var path = require('path');
 
   var projectRoot = ctx.opts.projectRoot;
   return (new Promise(function (resolve, reject) {


### PR DESCRIPTION
Fixes build on MABS 7 as it uses cordova-cli 10.0.0 which doesn't support 'requireCordovaModule' for native JS modules